### PR TITLE
Remove predicate/VALUEOVERRIDE

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,27 +3,19 @@
 /**
  * Waits for the condition function to return a truthy value.
  * @param  {function(): *} condition The function that will be called to check the condition.
- * @param  {function(param: *): *} [value=condition]
- * The function that will be called to determine the resolve value, if this function is not
- * condition then the result of the the condition check function will be passed to it.
  * @param {number} [interval=50] The interval in which to check the condition.
  * @return {Promise<*>} Resolves what the either condition or value function returned.
  */
 const nativePromise = Promise;
-module.exports = Promise => function waitFor(condition, value, interval) {
+module.exports = Promise => function waitFor(condition, interval) {
 	Promise = Promise || nativePromise;
-	value = value || condition;
 	interval = interval || 50;
 	return new Promise((resolve, reject) => {
 		const int = setInterval(() => {
 			try {
 				const isDone = condition();
 				if (isDone) {
-					if (condition === value) {
-						resolve(isDone);
-					} else {
-						resolve(value(isDone));
-					}
+					resolve(isDone);
 					clearInterval(int);
 				}
 			} catch (error) {

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Just run ```npm install promise-waitfor```
 # Documentation
 
 ```javascript
-Promise waitFor(Function condition, Function predicate = condition, interval int=50)
+Promise waitFor(Function condition, interval int=50)
 ```
 
 ## Examples
@@ -32,10 +32,7 @@ const waitFor = require('promise-waitfor')(YOUR_PROMISE_CONSTRUCTOR_HERE);
 waitFor(CONDITION)
 .then(...)
 
-waitFor(CONDITION, VALUEOVERRIDE)
-.then(...)
-
-waitFor(CONDITION, VALUEOVERRIDE, TEST_INTERVAL)
+waitFor(CONDITION, TEST_INTERVAL)
 .then(...)
 ```
 

--- a/test.js
+++ b/test.js
@@ -41,13 +41,6 @@ describe('waitFor', () => {
 		return waitFor(() => i >= 5);
 	});
 
-	it('Resolves value returned by the "value" function on resolve', () => {
-		let i = 0;
-		makeAutoClosingInterval(() => i++, 5, 10);
-		return waitFor(() => i >= 5, () => 42)
-		.then(v => assert(v === 42, 'Value is not 42'));
-	});
-
 	it('Rejects the error when the condition causes an error', () =>
 		waitFor(() => { throw new Error('WOOOOOOOO'); })
 		.then(() => assert.fail('Resolved', 'Rejected'), e => {


### PR DESCRIPTION
It took me a bit to understand what the `value` was for and it seems to me that this:

```js
waitFor(condition, predicate)
```

is the same as:

```js
waitFor(condition).then(predicate)
```

And given that it's not used anywhere else, maybe it can be taken out. It seems that it was written for a specific use case.

I'll update the tests, docs and semver major if you agree with this change