### PR TITLE
Add pre-baked method with global Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,12 @@
 
 /**
  * Waits for the condition function to return a truthy value.
+ * @param  {Function(): Promise} Promise An ES6-compatible Promise implementation.
  * @param  {Function(): *} condition The function that will be called to check the condition.
  * @param {Number} [interval=50] The interval in which to check the condition.
  * @return {Promise.<*>} Resolves what the either condition or value function returned.
  */
-const nativePromise = Promise;
-module.exports = Promise => function waitFor(condition, interval) {
-	Promise = Promise || nativePromise;
+function waitFor(Promise, condition, interval) {
 	interval = interval || 50;
 	return new Promise((resolve, reject) => {
 		const int = setInterval(() => {
@@ -24,4 +23,11 @@ module.exports = Promise => function waitFor(condition, interval) {
 			}
 		}, interval);
 	});
-};
+}
+
+function use (Promise) {
+	return waitFor.bind(null, Promise);
+}
+
+module.exports = use(Promise);
+module.exports.use = use;

--- a/readme.md
+++ b/readme.md
@@ -27,13 +27,19 @@ Promise waitFor(Function condition, interval int=50)
 ## Examples
 
 ```javascript
-const waitFor = require('promise-waitfor')(YOUR_PROMISE_CONSTRUCTOR_HERE);
+const waitFor = require('promise-waitfor');
 
 waitFor(CONDITION)
 .then(...)
 
 waitFor(CONDITION, TEST_INTERVAL)
 .then(...)
+```
+
+Alternatively, you can use a Promise constructor other than `global.Promise`:
+
+```javascript
+const waitFor = require('promise-waitfor').use(YOUR_PROMISE_CONSTRUCTOR_HERE);
 ```
 
 For now more info check test.js and the index.js for further information.

--- a/test.js
+++ b/test.js
@@ -2,14 +2,14 @@
 
 /*global describe:false, it:false*/
 
-const waitFor = require('./index.js')();
+const waitFor = require('./index.js');
 const assert = require('assert');
 
 describe('export', () => {
 	it('Correctly makes the function use the given promise implementation', () => {
 		const MyPromiseImp = class MyPromiseImp extends Promise {
 		};
-		const otherWaitFor = require('./index.js')(MyPromiseImp);
+		const otherWaitFor = waitFor.use(MyPromiseImp);
 		assert(
 			otherWaitFor(() => true) instanceof MyPromiseImp,
 			'Wrong promise implemetation'


### PR DESCRIPTION
Don't pull this in yet, it's just an example for something that would be nice to have in 2.0.

It's especially nice for usage with ES modules because this is currently necessary:

```js
import waitForGenerator from 'promise-waitfor';
const waitFor = waitForGenerator();
waitFor(...).then(...);
```

With this PR:

```js
import {waitFor} from 'promise-waitfor';
// or
const waitFor = require('promise-waitfor').waitFor;

waitFor(...).then(...);
```

**But** perhaps it'd be better to have the global `Promise` as the default export, and bother the developer with that extra function call only if they need a custom Promise. I didn't submit it because it changes the API and depends on #1 

```js
const waitFor = require('promise-waitfor'); // already usable with global.Promise
waitFor(...).then(...);
```

Or:

```js
const Promise = require('bluebird').Promise
const waitFor = require('promise-waitfor').use(Promise);
waitFor(...).then(...);
```